### PR TITLE
Move alert to content area

### DIFF
--- a/src/components/Alert/Alert.js
+++ b/src/components/Alert/Alert.js
@@ -29,7 +29,7 @@ class Alert extends Component {
 
     return (
       <div className={`tlbx-alert${isVisible ? ' open' : ''}`}>
-        <span>🚨</span>
+        <span role="img" aria-label="Alert">🚨</span>
         <p>Looks like you've built your styleguide using an <b>old version of toolbox-utils</b> (local <b>{alert.local_version || 'undefined'}</b>, current <b>{alert.remote_version}</b>).<br />See <a href="http://frontend.github.io/toolbox/updates.html">update doc</a>.</p>
         <button onClick={this.handleClose.bind(this)}>&times;</button>
       </div>

--- a/src/components/Alert/Alert.scss
+++ b/src/components/Alert/Alert.scss
@@ -4,7 +4,7 @@
   display: none;
   align-items: center;
   justify-content: space-between;
-  margin-left: $toolbar-width;
+  margin-left: 0;
   padding: 8px 20px;
   background: #FFD62B;
   font-size: 16px;
@@ -38,6 +38,5 @@
 
   @media only screen and (max-width: 767px) {
     margin-top: $toolbar-width;
-    margin-left: 0;
   }
 }

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -48,30 +48,28 @@ class App extends Component {
 
     if (hasStyleguideShell && hasHomeStyleguideShell) {
       return (
-        <div>
-          <Theme className="styleguide">
-            <div className="tlbx-toolbar-wrapper">
-              <Toolbar />
+        <Theme className="styleguide">
+          <div className="tlbx-toolbar-wrapper">
+            <Toolbar />
+          </div>
+          <div className={`tlbx-sidebar-wrapper${this.props.navigation.showMenu ? ' tlbx-sidebar-open' : ''}`}>
+            <Sidebar location={this.props.location} />
+          </div>
+          <div className="tlbx-content-wrapper">
+            <Alert />
+            <div className="tlbx-content">
+              <Switch>
+                {fullHome
+                  ? '' :
+                  <Route path="/" exact component={Doc} />
+                }
+                <Route path="/doc/:slug" component={Doc} />
+                <Route path="/colors" component={Colors} />
+                <Route path="/:type/:slug" component={SingleStyleguide} />
+              </Switch>
             </div>
-            <div className={`tlbx-sidebar-wrapper${this.props.navigation.showMenu ? ' tlbx-sidebar-open' : ''}`}>
-              <Sidebar location={this.props.location} />
-            </div>
-            <div className="tlbx-content-wrapper">
-              <Alert />
-              <div className="tlbx-content">
-                <Switch>
-                  {fullHome
-                    ? '' :
-                    <Route path="/" exact component={Doc} />
-                  }
-                  <Route path="/doc/:slug" component={Doc} />
-                  <Route path="/colors" component={Colors} />
-                  <Route path="/:type/:slug" component={SingleStyleguide} />
-                </Switch>
-              </div>
-            </div>
-          </Theme>
-        </div>
+          </div>
+        </Theme>
       );
     }
 

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -49,7 +49,6 @@ class App extends Component {
     if (hasStyleguideShell && hasHomeStyleguideShell) {
       return (
         <div>
-          <Alert />
           <Theme className="styleguide">
             <div className="tlbx-toolbar-wrapper">
               <Toolbar />
@@ -58,6 +57,7 @@ class App extends Component {
               <Sidebar location={this.props.location} />
             </div>
             <div className="tlbx-content-wrapper">
+              <Alert />
               <div className="tlbx-content">
                 <Switch>
                   {fullHome


### PR DESCRIPTION
I moved the alert in the content area. This avoids us having issues if the sidebar is overriden to be `position: fixed` and requiring a lot of CSS hacks to fix :D

**Before**:
![tlbx-alert-before](https://user-images.githubusercontent.com/1708450/41547018-67df45a6-731f-11e8-96f5-46a376ead6c0.gif)

**After**:
![tlbx-alert-after](https://user-images.githubusercontent.com/1708450/41547047-71cd7128-731f-11e8-8211-634562d38422.gif)

